### PR TITLE
fix: change content-type to text/plain

### DIFF
--- a/ads_txt/templates/ads_txt/rule_list.html
+++ b/ads_txt/templates/ads_txt/rule_list.html
@@ -1,7 +1,2 @@
-{% load l10n %}
-{% if rules %}
-{% for rule in rules %}
-{{ rule.domain }}, {{ rule.account_id }}, {{ rule.account_type }}{% if rule.authority_id %}, {{ rule.authority_id }}{% endif %}<br>
-{% endfor %}
-{% endif %}
-
+{% if rules %}{% for rule in rules %}{{ rule.domain }}, {{ rule.account_id }}, {{ rule.account_type }}{% if rule.authority_id %}, {{ rule.authority_id }}{% endif %}
+{% endfor %}{% endif %}

--- a/ads_txt/views.py
+++ b/ads_txt/views.py
@@ -9,6 +9,7 @@ class RuleList(ListView):
     model = Rule
     context_object_name = 'rules'
     cache_timeout = settings.CACHE_TIMEOUT
+    content_type = 'text/plain'
 
     def get_cache_timeout(self):
         return self.cache_timeout

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,16 +4,17 @@ from ads_txt.models import Rule
 
 
 class AdsTxtTest(TestCase):
-
     def setUp(self):
         self.client = Client()
-        Rule.objects.create(domain='test.com',
-                            account_id='121243d',
-                            account_type='DIRECT',
-                            authority_id=''
-                            )
+        Rule.objects.create(
+            domain='test.com',
+            account_id='121243d',
+            account_type='DIRECT',
+            authority_id='',
+        )
 
     def test_get_ads_txt(self):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('content-type'), 'text/plain')
         self.assertIn('test.com', str(response.content))


### PR DESCRIPTION
#5  ads.txt validator rejects the generated file because the returned content-type is `HTML` and has HTML tags `<br>`. 
This PR to change the returned content-type to `text/plain` and remove the HTML tags