### PR TITLE
Bulk upload ads.txt lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ https://github.com/flyingelephantlab/django-ads-txt/
 3. To activate ads.txt generation on your Django site, add this line to your [URLconf](https://docs.djangoproject.com/en/dev/topics/http/urls/):
 
 ```python
-url(r'^ads\.txt', include('ads_txt.urls')),
+url(r'', include('ads_txt.urls')),
+# Alternative:
+# path(r'', include('ads_txt.urls')),
 ```
 4. Add the domains you need to appear from admin panel
 

--- a/ads_txt/models.py
+++ b/ads_txt/models.py
@@ -1,3 +1,4 @@
+import re
 from django.contrib.sites.models import Site
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
@@ -28,3 +29,14 @@ class Rule(models.Model):
 
     def __str__(self):
         return self.domain
+
+    @staticmethod
+    def validate(line):
+        """
+            Specs:
+            https://iabtechlab.com/wp-content/uploads/2019/03/IAB-OpenRTB-Ads.txt-Public-Spec-1.0.2.pdf
+        """
+        # TODO: This regex does not support:
+        # 3.4.1 Comments, 3.5 Variables, 4.4 Contact Records, 4.5 Subdomain Referral, etc ...
+        pattern = r'(?P<domain>.+),\s*(?P<account_id>.+),\s*(?P<account_type>RESELLER|DIRECT)(,\s*(?P<authority_id>.+))?'
+        return re.search(pattern, line)

--- a/ads_txt/templates/ads_txt/admin/ads_txt/adstxt/change_list.html
+++ b/ads_txt/templates/ads_txt/admin/ads_txt/adstxt/change_list.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    <li>
+        <a href="{% url 'ads_txt_bulk_upload' %}" class="addlink">
+            Bulk Upload
+        </a>
+    </li>
+{% endblock %}

--- a/ads_txt/templates/ads_txt/change_form.html
+++ b/ads_txt/templates/ads_txt/change_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div>
     <form method="POST">
-        {{ form }}
+        {{ form.as_p }}
         {% csrf_token %}
         <button name="upload_ads" type="submit">Upload ADS</button>
     </form>

--- a/ads_txt/templates/ads_txt/change_form.html
+++ b/ads_txt/templates/ads_txt/change_form.html
@@ -1,0 +1,11 @@
+{% extends 'admin/base.html' %}
+
+{% block content %}
+<div>
+    <form method="POST">
+        {{ form }}
+        {% csrf_token %}
+        <button name="upload_ads" type="submit">Upload ADS</button>
+    </form>
+</div>
+{% endblock %}

--- a/ads_txt/urls.py
+++ b/ads_txt/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
-
-from ads_txt.views import rules_list
+from ads_txt.views import rules_list, bulk_upload_rules
 
 urlpatterns = [
+    url(r'upload/$', bulk_upload_rules, name='ads_txt_bulk_upload'),
     url(r'^$', rules_list, name='ads_txt_rule_list'),
 ]

--- a/ads_txt/urls.py
+++ b/ads_txt/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import url
 from ads_txt.views import rules_list, bulk_upload_rules
 
 urlpatterns = [
-    url(r'upload/$', bulk_upload_rules, name='ads_txt_bulk_upload'),
+    url(r'/upload/$', bulk_upload_rules, name='ads_txt_bulk_upload'),
     url(r'^$', rules_list, name='ads_txt_rule_list'),
 ]

--- a/ads_txt/urls.py
+++ b/ads_txt/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import url
 from ads_txt.views import rules_list, bulk_upload_rules
 
 urlpatterns = [
-    url(r'/upload/$', bulk_upload_rules, name='ads_txt_bulk_upload'),
-    url(r'^$', rules_list, name='ads_txt_rule_list'),
+    url(r'^ads\.txt', rules_list, name='ads_txt_rule_list'),
+    url(r'^ads_txt/upload', bulk_upload_rules, name='ads_txt_bulk_upload'),
 ]

--- a/ads_txt/views.py
+++ b/ads_txt/views.py
@@ -55,7 +55,7 @@ class BulkRulesForm(forms.Form):
             matches.append(match.groupdict())
 
         if errors:
-            raise forms.ValidationError(_('Error reading lines:\n') + '\n'.join(errors))
+            raise forms.ValidationError(_('Error reading lines:\n') + ',\n'.join(errors))
 
         cleaned_data['ads_rules'] = matches
         return cleaned_data

--- a/ads_txt/views.py
+++ b/ads_txt/views.py
@@ -69,7 +69,11 @@ class UploadRulesFormView(FormView):
     def form_valid(self, form):
         ads_list = form.cleaned_data.get('ads_rules')
         for ads_dict in ads_list:
-            Rule.objects.get_or_create(**ads_dict)
+            try:
+                Rule.objects.get_or_create(**ads_dict)
+            except Rule.MultipleObjectsReturned:
+                Rule.objects.filter(**ads_dict).delete()
+                Rule.objects.get_or_create(**ads_dict)
 
         messages.add_message(self.request, messages.SUCCESS, _('ads.txt rules updated with success'))
         return HttpResponseRedirect(self.get_success_url())

--- a/ads_txt/views.py
+++ b/ads_txt/views.py
@@ -1,5 +1,6 @@
 from django.views.decorators.cache import cache_page
 from django.views.generic import ListView
+from django.views.generic.edit import FormView
 
 from ads_txt import settings
 from ads_txt.models import Rule
@@ -22,5 +23,60 @@ class RuleList(ListView):
         cache_decorator = cache_page(cache_timeout)
         return cache_decorator(super_dispatch)(request, *args, **kwargs)
 
+from django import forms
+from django.contrib import messages
+from django.urls import reverse_lazy
+from django.utils.translation import ugettext_lazy as _
+from django.http import HttpResponseRedirect
+from django.utils.decorators import method_decorator
+from django.contrib.admin.views.decorators import staff_member_required
+
+
+class BulkRulesForm(forms.Form):
+
+    ads_rules = forms.CharField(widget=forms.Textarea)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        ads_rules = cleaned_data.get('ads_rules')
+
+        matches, errors = [], []
+        for index, rule in enumerate(
+                ads_rules.splitlines(keepends=False), start=1):
+
+            if not rule.strip():
+                continue
+
+            match = Rule.validate(rule.strip())
+            if not match:
+                errors.append(str(index))
+                continue
+
+            matches.append(match.groupdict())
+
+        if errors:
+            raise forms.ValidationError(_('Error reading lines:\n') + '\n'.join(errors))
+
+        cleaned_data['ads_rules'] = matches
+        return cleaned_data
+
+@method_decorator(staff_member_required, name='dispatch')
+class UploadRulesFormView(FormView):
+    template_name = "ads_txt/change_form.html"
+    form_class = BulkRulesForm
+    success_url = reverse_lazy('admin:index')
+
+    def form_valid(self, form):
+        ads_list = form.cleaned_data.get('ads_rules')
+        for ads_dict in ads_list:
+            Rule.objects.get_or_create(**ads_dict)
+
+        messages.add_message(self.request, messages.SUCCESS, _('ads.txt rules updated with success'))
+        return HttpResponseRedirect(self.get_success_url())
+
+    def form_invalid(self, form):
+        messages.add_message(self.request, messages.ERROR, _('Failed to update ads.txt'))
+        return self.render_to_response(self.get_context_data(form=form))
 
 rules_list = RuleList.as_view()
+bulk_upload_rules = UploadRulesFormView.as_view()

--- a/runtests.py
+++ b/runtests.py
@@ -7,7 +7,10 @@ DEFAULT_SETTINGS = dict(
     INSTALLED_APPS=[
         'django.contrib.auth',
         'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.admin',
         'django.contrib.sites',
+        'django.contrib.messages',
         'ads_txt',
     ],
     DATABASES={
@@ -17,7 +20,7 @@ DEFAULT_SETTINGS = dict(
     },
     ROOT_URLCONF='test_utils.urls',
     SITE_ID=1,
-    MIDDLEWARE_CLASSES=[
+    MIDDLEWARE=[
         'django.middleware.http.ConditionalGetMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -29,7 +32,15 @@ DEFAULT_SETTINGS = dict(
     TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
-    }]
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    }],
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-ads-txt',
-    version='0.1.2',
+    version='0.2.0',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',
@@ -24,12 +24,14 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-ads-txt',
-    version='0.2.0',
+    version='1.2.1',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
+from django.urls import reverse
 from django.test import Client, TestCase
-
+from django.contrib.auth.models import User
 from ads_txt.models import Rule
-
 
 class AdsTxtTest(TestCase):
     def setUp(self):
@@ -18,3 +18,29 @@ class AdsTxtTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get('content-type'), 'text/plain')
         self.assertIn('test.com', str(response.content))
+
+
+class UploadAdsTxtTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.password = 'my@password123' 
+        self.user = User.objects.create_superuser(
+            'admin', 'admin@test.com', self.password)
+
+    def test_bulk_upload_unauthorized(self):
+        response = self.client.get(reverse('ads_txt_bulk_upload'), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('content-type'), 'text/html; charset=utf-8')
+        self.assertIn('Log in | Django site admin', str(response.content))
+
+    def test_bulk_upload_get(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(reverse('ads_txt_bulk_upload'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(response.get('content-type'), 'text/html; charset=utf-8')
+
+    def test_bulk_upload_post(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.post(reverse('ads_txt_bulk_upload'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(response.get('content-type'), 'text/html; charset=utf-8')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,10 @@
-from django.urls import reverse
+from django.urls import reverse_lazy
 from django.test import Client, TestCase
 from django.contrib.auth.models import User
 from ads_txt.models import Rule
 
 class AdsTxtTest(TestCase):
+
     def setUp(self):
         self.client = Client()
         Rule.objects.create(
@@ -21,6 +22,7 @@ class AdsTxtTest(TestCase):
 
 
 class UploadAdsTxtTest(TestCase):
+
     def setUp(self):
         self.client = Client()
         self.password = 'my@password123' 
@@ -28,19 +30,47 @@ class UploadAdsTxtTest(TestCase):
             'admin', 'admin@test.com', self.password)
 
     def test_bulk_upload_unauthorized(self):
-        response = self.client.get(reverse('ads_txt_bulk_upload'), follow=True)
+        response = self.client.get(
+            reverse_lazy('ads_txt_bulk_upload'), follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get('content-type'), 'text/html; charset=utf-8')
-        self.assertIn('Log in | Django site admin', str(response.content))
+        self.assertIn('text/html;', response.get('content-type'))
+        self.assertContains(response, 'Log in | Django site admin')
 
     def test_bulk_upload_get(self):
         self.client.login(username=self.user.username, password=self.password)
-        response = self.client.get(reverse('ads_txt_bulk_upload'))
+        response = self.client.get(
+            reverse_lazy('ads_txt_bulk_upload'))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(response.get('content-type'), 'text/html; charset=utf-8')
+        self.assertIn('text/html;', response.get('content-type'))
 
     def test_bulk_upload_post(self):
+
+        data = {'ads_rules': '\n'.join([
+            "test.com, 121243d, DIRECT",
+            "test.com, re121243d, RESELLER, re121243d"])
+        }
+
         self.client.login(username=self.user.username, password=self.password)
-        response = self.client.post(reverse('ads_txt_bulk_upload'))
+        response = self.client.post(
+            reverse_lazy('ads_txt_bulk_upload'), data, follow=True)
+
         self.assertEqual(response.status_code, 200)
-        self.assertIn(response.get('content-type'), 'text/html; charset=utf-8')
+        self.assertIn('text/html;', response.get('content-type'))
+        self.assertContains(response, 'rules updated with success')
+
+    def test_bulk_upload_post_invalid(self):
+
+        data = {'ads_rules': '\n'.join([
+            "test.com121243d, DIRECT",
+            "test.com, re121243d, RESELLER, re121243d\r\n",
+            "\r\n",
+            "test.com, re121243d, re121243d"
+            "\n"])
+        }
+
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.post(
+            reverse_lazy('ads_txt_bulk_upload'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Failed to update')
+        self.assertContains(response, 'Error reading lines')


### PR DESCRIPTION
1. Update runtests.py in order to work on Django 2.2
2. Five new testcases for this feature
3. Validation regex in the model - Not perfect, but does the job
4. Simple from `ads_txt/change_form.html`
5. New URL `upload/` on  `ads_txt/urls.py`- We can discuss about the name/place
6. BulkRulesForm and UploadRulesFormView

Perhaps `upload/` should be part of admin, but feels too much of hack:
https://gist.github.com/gpietro/7d6f17f95ced52f24dbacd78d1d49bb6

The other option was to add dependencies...